### PR TITLE
Misc fixes to rct-exports.

### DIFF
--- a/src/construct-column-data.js
+++ b/src/construct-column-data.js
@@ -270,9 +270,9 @@ export async function constructChatbotInteractions(context) {
         PARTITION BY authority, json_extract(embed_path, '$[0]')
         ORDER BY json_extract(extensions, '$.chatbotEvent.userPrompt.timestamp')
       ) - 1 AS 'Order of Interaction',
-      json_extract(extensions, '$.chatbotEvent.userPrompt.text')  AS 'User Query(original)',
+      json_extract(extensions, '$.chatbotEvent.userPrompt.text')  AS 'User Query',
       json_extract(extensions, '$.chatbotEvent.userPrompt.timestamp') AS 'User Query Timestamp',
-      json_extract(extensions, '$.chatbotEvent.botResponse.text') AS 'Chatbot Response(original)',
+      json_extract(extensions, '$.chatbotEvent.botResponse.text') AS 'Chatbot Response',
       json_extract(extensions, '$.chatbotEvent.botResponse.timestamp') AS 'Chatbot Response Timestamp',
       json_extract(extensions, '$.chatbotEvent.llmInstructions') AS 'LLM Instructions'
     FROM statements

--- a/src/construct-column-data.js
+++ b/src/construct-column-data.js
@@ -270,8 +270,8 @@ export async function constructChatbotInteractions(context) {
         PARTITION BY authority, json_extract(embed_path, '$[0]')
         ORDER BY json_extract(extensions, '$.chatbotEvent.userPrompt.timestamp')
       ) - 1 AS 'Order of Interaction',
-      json_extract(extensions, '$.chatbotEvent.userPrompt.text')  AS 'User Query',
-      json_extract(extensions, '$.chatbotEvent.userPrompt.timestamp') AS 'User Query Timestamp',
+      json_extract(extensions, '$.chatbotEvent.userPrompt.text')  AS 'Student Query',
+      json_extract(extensions, '$.chatbotEvent.userPrompt.timestamp') AS 'Student Query Timestamp',
       json_extract(extensions, '$.chatbotEvent.botResponse.text') AS 'Chatbot Response',
       json_extract(extensions, '$.chatbotEvent.botResponse.timestamp') AS 'Chatbot Response Timestamp',
       json_extract(extensions, '$.chatbotEvent.llmInstructions') AS 'LLM Instructions'

--- a/src/rct-utils.js
+++ b/src/rct-utils.js
@@ -102,7 +102,18 @@ export function getStudentAnswerText(runState, problem) {
 
         case 'word_problem':
             if (state.answerBlockValues) {
-                return Object.values(state.answerBlockValues).join('; ');
+                const answerBlockValues = problem.answerBlocks.map(
+                    (block, index) => {
+                        if (block.label && block.orientation === 'label_first') {
+                            return `${block.label} ${state.answerBlockValues[index] || 'No Answer'}`;
+                        } else if (block.label && block.orientation === 'value_first') {
+                            return `${state.answerBlockValues[index] || 'No Answer'} ${block.label}`;
+                        } else {
+                            return state.answerBlockValues[index] || 'No Answer';
+                        }
+                    }
+                );
+                return answerBlockValues.join('; ');
             }
             break;
 


### PR DESCRIPTION
   - In word problems, ensure that “correct answer” follows same format as answer 1 to 3 (cleaned xapi file)
   - Rename “chatbot response (original)” to “chatbot response”
   - Rename “user query (original)” to “student query”; Also change the timestamp fields